### PR TITLE
Add a no-restore option to the cache action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
+  no-restore:
+    description: 'Do not restore the cache on hit, useful for jobs who merely build the cached dependency.'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,7 @@ inputs:
   no-restore:
     description: 'Do not restore the cache on hit, useful for jobs who merely build the cached dependency.'
     required: false
+    default: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export enum Inputs {
     Key = "key",
     Path = "path",
     RestoreKeys = "restore-keys",
-    UploadChunkSize = "upload-chunk-size"
+    UploadChunkSize = "upload-chunk-size",
+    NoRestore = "no-restore"
 }
 
 export enum Outputs {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -28,6 +28,17 @@ async function run(): Promise<void> {
         const cachePaths = utils.getInputAsArray(Inputs.Path, {
             required: true
         });
+        
+        // Before restoring cache, check no-restore option
+        const noRestore = core.getBooleanInput(Inputs.NoRestore, { required: false });
+        if (noRestore) {
+            const keys = [primaryKey];
+            const cacheEntry = await cache.getCacheEntry(keys, cachePaths);
+            if (cacheEntry?.archiveLocation) {
+                utils.setCacheHitOutput(true);
+                return;
+            }
+        }
 
         const cacheKey = await cache.restoreCache(
             cachePaths,

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -34,7 +34,8 @@ async function run(): Promise<void> {
         if (noRestore) {
             const keys = [primaryKey];
             const cacheEntry = await cache.getCacheEntry(keys, cachePaths);
-            if (cacheEntry?.archiveLocation) {
+            if (cacheEntry?.archiveLocation) {        
+                core.info(`Cache entry found, skipping restore`);
                 utils.setCacheHitOutput(true);
                 return;
             }


### PR DESCRIPTION
This can be useful for jobs who merely build the cached dependency, and which don't need to restore the data on a cache hit.